### PR TITLE
Fix box collide error

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -187,7 +187,6 @@ class PlayState extends FlxState
 
 		hud.update(elapsed);
 
-		FlxG.collide(_mGround, player);
 
 		// Add overlap logic
 		FlxG.overlap(blockGroup, player.hitBoxComponents, function(b:Block, obj:FlxObject) {b.onTouch(obj, player);} );

--- a/source/Player.hx
+++ b/source/Player.hx
@@ -74,6 +74,8 @@ import flixel.group.FlxGroup;
     btmBox = new FlxObject(X + hitBoxWidthOffset, Y + height - hitBoxHeight, width - hitBoxWidthOffset*2, hitBoxHeight);
     hitBoxComponents.add(topBox);
     hitBoxComponents.add(btmBox);
+	
+	FlxG.state.add(hitBoxComponents);
 	}
 
 	/**


### PR DESCRIPTION
I know it's a bit hypocritical of me to set up a pull request with hardly any content after everything I told you guys in class, but this PR is very, very small. It fixes a problem that had been occurring with player-box collision that resulted from player hitboxes not being added to the playstate.

I also removed an unnecessary call to collide. See the commit messages below for details.

I tested it to make sure it works, but please make sure it works for you too.

I would've just sent an email, but I figured this was the easiest way to get your attention. I'll also throw your name in here. I'm not sure what is necessary to make Github send you a notification. @sjf60780 